### PR TITLE
@summary is missing

### DIFF
--- a/content/en/plugins-markdown.md
+++ b/content/en/plugins-markdown.md
@@ -24,6 +24,7 @@ comment)
 + [`@property`][property-tag]
 + [`@returns`][returns-tag]
 + [`@see`][see-tag]
++ [`@summary`][summary-tag]
 + [`@throws`][throws-tag]
 
 [additional-tags]: #additional-tags
@@ -35,6 +36,7 @@ comment)
 [property-tag]: tags-property.html
 [returns-tag]: tags-returns.html
 [see-tag]: tags-see.html
+[summary-tag]: tags-summary.html
 [throws-tag]: tags-throws.html
 
 


### PR DESCRIPTION
Haven't built this, but I see that @summary is in source, so I believe it should be here.

(I notice @example gets syntax highlighting added in the default template, but it is not in that list or in source along with the other `defaultTags`. And when adding `tags` to the Markdown plugin like `examples`, I get `<pre>` and `<code>` shown visibly, I guess because the template isn't adjusted to handle them.)